### PR TITLE
Clone xhr response

### DIFF
--- a/src/ResponseWrapper.ts
+++ b/src/ResponseWrapper.ts
@@ -1,6 +1,6 @@
-import {nonenumerable} from 'core-decorators';
 import * as li from 'parse-link-header';
 import * as Constants from './Constants';
+import nonenumerable from './helpers/nonenumerable';
 
 export interface IResponseWrapper {
     mediaType: string;
@@ -14,11 +14,7 @@ export class ResponseWrapper implements IResponseWrapper {
     private readonly originalResponse: Response;
 
     constructor(res: Response) {
-        Object.defineProperty(this, 'originalResponse', {
-            enumerable: false,
-            value: res,
-            writable: true,
-        });
+        this.originalResponse = res;
     }
 
     get xhr() {

--- a/src/ResponseWrapper.ts
+++ b/src/ResponseWrapper.ts
@@ -1,3 +1,4 @@
+import {nonenumerable} from 'core-decorators';
 import * as li from 'parse-link-header';
 import * as Constants from './Constants';
 
@@ -9,10 +10,19 @@ export interface IResponseWrapper {
 }
 
 export class ResponseWrapper implements IResponseWrapper {
-    public readonly xhr: Response;
+    @nonenumerable
+    private readonly originalResponse: Response;
 
     constructor(res: Response) {
-        this.xhr = res;
+        Object.defineProperty(this, 'originalResponse', {
+            enumerable: false,
+            value: res,
+            writable: true,
+        });
+    }
+
+    get xhr() {
+        return this.originalResponse.clone();
     }
 
     get status(): number {

--- a/src/helpers/nonenumerable.ts
+++ b/src/helpers/nonenumerable.ts
@@ -1,0 +1,17 @@
+export default function nonenumerable(target: any, key: string) {
+    // first property defined in prototype, that's why we use getters/setters
+    // (otherwise assignment in object will override property in prototype)
+    Object.defineProperty(target, key, {
+        get: () => undefined,
+        set(this: any, val) {
+            // here we have reference to instance and can set property directly to it
+            Object.defineProperty(this, key, {
+                enumerable: false,
+                value: val,
+                writable: true,
+            });
+        },
+
+        enumerable: false,
+    });
+}

--- a/tests/ResponseWrapper-spec.ts
+++ b/tests/ResponseWrapper-spec.ts
@@ -20,6 +20,7 @@ describe('ResponseWrapper', () => {
             redirected: true,
             url: 'urn:actual:resource',
         } as Response;
+        xhrResponse.clone = () => xhrResponse;
 
         // when
         const res = new ResponseWrapper(xhrResponse);
@@ -38,5 +39,10 @@ describe('ResponseWrapper', () => {
         // then
         expect(await res.xhr.text()).toBe('some text');
         expect(await res.xhr.text()).toBe('some text');
+    });
+
+    it('should not expose originalResponse', () => {
+        expect(Object.getOwnPropertyDescriptor(ResponseWrapper.prototype, 'originalResponse').enumerable)
+            .toBe(false);
     });
 });

--- a/tests/ResponseWrapper-spec.ts
+++ b/tests/ResponseWrapper-spec.ts
@@ -27,4 +27,16 @@ describe('ResponseWrapper', () => {
         // then
         expect(res.redirectUrl).toBe('urn:actual:resource');
     });
+
+    it('should be possible to read response multiple times', async () => {
+        // given
+        const xhrResponse = await responseBuilder().body('some text').build();
+
+        // when
+        const res = new ResponseWrapper(xhrResponse);
+
+        // then
+        expect(await res.xhr.text()).toBe('some text');
+        expect(await res.xhr.text()).toBe('some text');
+    });
 });

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -102,12 +102,17 @@ export async function mockedResponse({ includeDocsLink = true, xhrBuilder = null
     xhrBuilder = xhrBuilder || responseBuilder();
     const xhr = await xhrBuilder.build();
 
-    return {
+    const response = {
         apiDocumentationLink: includeDocsLink ? 'http://api.example.com/doc/' : null,
         mediaType: xhr.headers.get('Content-Type'),
         redirectUrl: null,
-        xhr,
     };
+
+    Object.defineProperty(response, 'xhr', {
+        get: () => xhr.clone(),
+    });
+
+    return response as IResponseWrapper;
 }
 
 function addPredicateGetter(prop: string, pred: string, wrapArray: boolean = true) {


### PR DESCRIPTION
Makes it possible to read the response body once it's been already processed

```js
const rep = await client.loadResource('http://wikibus-test.gear.host/brochures?page=1');

// would fail before
await rep.text();
```