### PR TITLE
Node-friendly package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,20 +2,24 @@
   "name": "alcaeus",
   "version": "0.4.3",
   "description": "Hydra Core hypermedia-aware client library",
-  "main": "lib/index.js",
+  "main": "lib/node/index.js",
   "types": "types/index.d.ts",
+  "module": "lib/es/index.js",
+  "module.root": "lib/es",
   "directories": {
     "test": "tests"
   },
   "files": [
     "dist",
     "types",
-    "lib",
-    "src/*.ts"
+    "lib"
   ],
   "scripts": {
     "test": "yarn lint; yarn run karma start --single-run",
-    "build": "tsc; webpack; gitbook install; gitbook build . docs/latest",
+    "build": "yarn run build:nodejs; yarn run build:default; webpack; yarn run build:gitbook",
+    "build:nodejs": "tsc --target es2017 --module commonjs --outDir lib/node",
+    "build:default": "tsc --target esnext --module esnext --outDir lib/es",
+    "build:gitbook": "gitbook install; gitbook build . docs/latest",
     "lint": "tslint -p tsconfig.json",
     "prepublishOnly": "rm -rf dist; npm run build"
   },
@@ -38,9 +42,9 @@
   },
   "homepage": "https://github.com/wikibus/alcaeus#readme",
   "dependencies": {
-    "es6-url-template": "^1.0.0",
+    "es6-url-template": "^1.0.3",
     "isomorphic-fetch": "^2.2.1",
-    "jsonld": "^0.4.12",
+    "jsonld": "^1.1.0",
     "parse-link-header": "^1.0.1",
     "rdf-ext": "^1.0.0",
     "rdf-parser-jsonld": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:default": "tsc --target esnext --module esnext --outDir lib/es",
     "build:gitbook": "gitbook install; gitbook build . docs/latest",
     "lint": "tslint -p tsconfig.json",
-    "prepublishOnly": "rm -rf dist; npm run build"
+    "prepublishOnly": "rm -rf dist lib; yarn build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist",
     "types",
     "lib",
-    "src"
+    "src/*.ts"
   ],
   "scripts": {
     "test": "yarn lint; yarn run karma start --single-run",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "./lib/",
     "target": "esnext",
-    "module": "esnext",
     "moduleResolution": "node",
     "sourceMap": true,
     "emitDecoratorMetadata": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,9 +2029,9 @@ es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
     d "1"
     es5-ext "~0.10.14"
 
-es6-url-template@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es6-url-template/-/es6-url-template-1.0.0.tgz#8987412d1b95e90b529804709a5186cc3f26d456"
+es6-url-template@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/es6-url-template/-/es6-url-template-1.0.3.tgz#a753580a67b01c232f41b08e26e1234e3688003e"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"
@@ -3168,7 +3168,7 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonld@^0.4.11, jsonld@^0.4.12:
+jsonld@^0.4.11:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-0.4.12.tgz#a02f205d5341414df1b6d8414f1b967a712073e8"
   dependencies:
@@ -3180,6 +3180,15 @@ jsonld@^0.4.11, jsonld@^0.4.12:
 jsonld@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.0.2.tgz#c08118a4fa4a8457bf98891653ed1f1613eb6152"
+  dependencies:
+    rdf-canonize "^0.2.1"
+    request "^2.83.0"
+    semver "^5.5.0"
+    xmldom "0.1.19"
+
+jsonld@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.1.0.tgz#afcb168c44557a7bddead4d4513c3cbcae3bc5b9"
   dependencies:
     rdf-canonize "^0.2.1"
     request "^2.83.0"


### PR DESCRIPTION
This introduces a dual-packaging, so that when added to a project, Alcaeus can be used both from node.js (commonjs build) and bundlers (full-featured es6 build).

fixes #38 