### PR TITLE
fix: revert modules deps to support commonjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3685,41 +3685,11 @@
         "rimraf": "^2.5.2"
       }
     },
-    "@rdf-esm/data-model": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/data-model/-/data-model-0.5.0.tgz",
-      "integrity": "sha512-wgxQolJNFCrzI4xukXRQN4iNZENCS+kxO7cqsOqbrgm8hvahClThS1TIaDIKWhmfkoxhvp9E9hDsQSfqAh2shg==",
-      "requires": {
-        "@types/rdf-js": "^2.0.1"
-      }
-    },
-    "@rdf-esm/formats-common": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/formats-common/-/formats-common-0.5.0.tgz",
-      "integrity": "sha512-mJW8QfBzQNhhtveFOM3W5/B3GQ0PjCNHo1AmWHiqVq3WWbJnNIt1WmucPhJEPnPoyC6WR+9kCSzDSSDvnKgeKg==",
-      "requires": {
-        "@rdf-esm/sink-map": "github:rdf-esm/sink-map",
-        "@rdfjs/parser-jsonld": "^1.1.1",
-        "@rdfjs/parser-n3": "^1.1.2",
-        "@rdfjs/serializer-jsonld": "^1.2.0",
-        "@rdfjs/serializer-ntriples": "^1.0.1",
-        "rdfxml-streaming-parser": "^1.2.0"
-      },
-      "dependencies": {
-        "@rdf-esm/sink-map": {
-          "version": "github:rdf-esm/sink-map#7ec96e356bd38c67da61153652eca3266c1faacd",
-          "from": "github:rdf-esm/sink-map",
-          "requires": {
-            "@types/rdf-js": "^2.0.2",
-            "readable-stream": "^3.6.0"
-          }
-        }
-      }
-    },
     "@rdf-esm/sink-map": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@rdf-esm/sink-map/-/sink-map-0.5.0.tgz",
       "integrity": "sha512-0f2zQ6sdpD+5epgxlCjL6WJiEXsL/0nheF0rknSFclPBVoXLmj2F6Q0paQYVec05ni0r+KL8H+skEIuBTqgQMg==",
+      "dev": true,
       "requires": {
         "@types/rdf-js": "^2.0.2",
         "readable-stream": "^3.6.0"
@@ -3731,6 +3701,20 @@
       "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
       "requires": {
         "@types/rdf-js": "^2.0.1"
+      }
+    },
+    "@rdfjs/formats-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/formats-common/-/formats-common-2.1.0.tgz",
+      "integrity": "sha512-DVsQsMwSf+bNelIocDe35Wq/POkC+puXYd0BRwP76A3tzYKjIHwBHQFfq7wXMUaBe3jQq80x4DaFpxPaI7sPKA==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/parser-jsonld": "^1.1.1",
+        "@rdfjs/parser-n3": "^1.1.2",
+        "@rdfjs/serializer-jsonld": "^1.2.0",
+        "@rdfjs/serializer-ntriples": "^1.0.1",
+        "@rdfjs/sink-map": "^1.0.0",
+        "rdfxml-streaming-parser": "^1.2.0"
       }
     },
     "@rdfjs/namespace": {
@@ -3745,6 +3729,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/parser-jsonld/-/parser-jsonld-1.2.0.tgz",
       "integrity": "sha512-jn5QWljPdwKhNK4+Y+jjthtBcnt0q0ldB397KmXGR1u8d1Kvn8hYiiRrwypzgQuxaNFPwuOUuBK9xx3N/kWInA==",
+      "dev": true,
       "requires": {
         "@rdfjs/data-model": "^1.0.1",
         "@rdfjs/sink": "^1.0.2",
@@ -3757,6 +3742,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.1.tgz",
           "integrity": "sha512-f0rusl5v8aPKS3jApT5fhYsdTC/JpyK1PoJ+ZtYYtZXoyb1J0Z///mJqLwrfL/g4NueFSqPymDYIi1CcSk7b8Q==",
+          "dev": true,
           "requires": {
             "canonicalize": "^1.0.1",
             "rdf-canonize": "^1.0.2",
@@ -3769,6 +3755,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3785,6 +3772,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-1.1.3.tgz",
       "integrity": "sha512-TRvAA2QfrIdIfhDB9RVU91dhZ/ITDiJ1prTHahEgEVKNH+Zu+iFfEgLDKbv/ZNvEoLaDyoG92p9xqToH7mdh0w==",
+      "dev": true,
       "requires": {
         "@rdfjs/data-model": "^1.0.1",
         "@rdfjs/sink": "^1.0.2",
@@ -3796,6 +3784,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3812,6 +3801,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld/-/serializer-jsonld-1.2.2.tgz",
       "integrity": "sha512-BXcmi2qZlpkrJcVms9g1JSFWXeiOhgJyFsEa6UuN0CPst6WRNY5z6djp0o6rfDgfmgb5FrXFwBgAIDunI5VZoQ==",
+      "dev": true,
       "requires": {
         "@rdfjs/sink": "^1.0.2",
         "readable-stream": "^3.6.0"
@@ -3821,6 +3811,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/serializer-ntriples/-/serializer-ntriples-1.0.3.tgz",
       "integrity": "sha512-XXFgzNJyYrix0YgysqYowKw40hCJ+zeVqA/CGgO3y5XyKY+NL/VJJELMn7cTwjJteiLVCgRNAvaUVn4CjJ2PCg==",
+      "dev": true,
       "requires": {
         "@rdfjs/sink": "^1.0.3",
         "@rdfjs/to-ntriples": "^1.0.2",
@@ -3830,19 +3821,28 @@
         "@rdfjs/sink": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
-          "integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA=="
+          "integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA==",
+          "dev": true
         },
         "@rdfjs/to-ntriples": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-          "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA=="
+          "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
+          "dev": true
         }
       }
     },
     "@rdfjs/sink": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.2.tgz",
-      "integrity": "sha512-OCrxe+2CGy12xS8yjUMIUtbUI9jjM1WSvbw24JTJBo9jWf6pmeyk5IkMwI/Y8Sj/m2RajFiECMoP5MybIOAOSw=="
+      "integrity": "sha512-OCrxe+2CGy12xS8yjUMIUtbUI9jjM1WSvbw24JTJBo9jWf6pmeyk5IkMwI/Y8Sj/m2RajFiECMoP5MybIOAOSw==",
+      "dev": true
+    },
+    "@rdfjs/sink-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-1.0.1.tgz",
+      "integrity": "sha512-PRp5TjULHe2oRcupR80SClZ/l50wnSuX2Pl+TlkcRazt1w7AT86kLmQYFbDfjqGM7uDwSyD6evLJxXBDf5UuvQ==",
+      "dev": true
     },
     "@rdfjs/term-set": {
       "version": "1.0.1",
@@ -3917,9 +3917,9 @@
       "dev": true
     },
     "@tpluscode/rdf-ns-builders": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-0.1.0.tgz",
-      "integrity": "sha512-HxcNaUSZZOIBS8pdYiyRodFejLCcrleCMc/b8qdHA8bw830u5JOomSBZKRgylEAaps69G7PQPWtwvAEFSPRcKQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-0.2.2.tgz",
+      "integrity": "sha512-MBzEHKxkojFXk4WH00CHLeKHevS//UyicySHrd9gz8HP4VnZrD18LGVYSsADZ19FsHFoW7jTFgcfwZ89nEkyKQ==",
       "requires": {
         "@rdfjs/namespace": "^1.1.0",
         "@types/rdf-js": "^2.0.11",
@@ -3987,6 +3987,18 @@
         "clownface": "^0.12.1",
         "esm": "^3.2.25",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@tpluscode/rdf-ns-builders": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-0.1.0.tgz",
+          "integrity": "sha512-HxcNaUSZZOIBS8pdYiyRodFejLCcrleCMc/b8qdHA8bw830u5JOomSBZKRgylEAaps69G7PQPWtwvAEFSPRcKQ==",
+          "requires": {
+            "@rdfjs/namespace": "^1.1.0",
+            "@types/rdf-js": "^2.0.11",
+            "@types/rdfjs__namespace": "^1.1.1"
+          }
+        }
       }
     },
     "@types/babel__core": {
@@ -4134,6 +4146,16 @@
         "@types/node": "*"
       }
     },
+    "@types/rdfjs__formats-common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-2.0.0.tgz",
+      "integrity": "sha512-sMKreVx5Ij/UVlYFG9tzEwCV3ztn784J+Vb6yp/Roc5LH2FFA87O4V3GtX0y6aZ9Ry/C54GJoe2HY3+1SI+o5Q==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*",
+        "@types/rdfjs__sink-map": "*"
+      }
+    },
     "@types/rdfjs__namespace": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-1.1.1.tgz",
@@ -4156,6 +4178,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-1.1.2.tgz",
       "integrity": "sha512-9YDhj3rUjzm5Y61Xl6H3uOexFIvjUbfg6+WHdxN97LjxkHNnmn4yEP/UjShYOvznPkIcjPvfUXrLjvJMdKN1xQ==",
+      "dev": true,
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "@types/rdfjs__sink-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-1.0.0.tgz",
+      "integrity": "sha512-yci4F5SciD8W8d7elmWYaMv2igiz7cGzga/3LWRKTjA5xW8C22CGUWL7/4nwq9YYpSV9DyNA+21rOxBuGDQQcA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
@@ -4373,6 +4404,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4671,6 +4703,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -4678,7 +4711,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -4721,12 +4755,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -5132,6 +5168,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -5354,7 +5391,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtins": {
       "version": "1.0.3",
@@ -5470,7 +5508,8 @@
     "canonicalize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.1.tgz",
-      "integrity": "sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg=="
+      "integrity": "sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -5490,7 +5529,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "2.3.1",
@@ -5787,6 +5827,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -5798,6 +5839,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6007,7 +6049,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -6120,6 +6163,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -6470,6 +6514,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -7258,7 +7303,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -7366,17 +7412,20 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -7548,7 +7597,8 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
@@ -8379,6 +8429,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -8681,12 +8732,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -8827,6 +8880,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -9480,7 +9534,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -9497,7 +9552,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -9522,7 +9578,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-instrumenter-loader": {
       "version": "3.0.1",
@@ -10389,7 +10446,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
@@ -10457,12 +10515,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-server": {
       "version": "0.12.2",
@@ -10503,7 +10563,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -10548,6 +10609,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -11563,7 +11625,8 @@
     "n3": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/n3/-/n3-1.3.5.tgz",
-      "integrity": "sha512-McWb1tCWGGAmHeGEakqZj/UqxQR9cpEYZ/JivBj59YfiOAuaIWZxu0B+jnhbCwCZ2AsxdgQ5Dq8fehIJpYQaMQ=="
+      "integrity": "sha512-McWb1tCWGGAmHeGEakqZj/UqxQR9cpEYZ/JivBj59YfiOAuaIWZxu0B+jnhbCwCZ2AsxdgQ5Dq8fehIJpYQaMQ==",
+      "dev": true
     },
     "nan": {
       "version": "2.14.1",
@@ -11678,7 +11741,8 @@
     "node-forge": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+      "dev": true
     },
     "node-gyp": {
       "version": "3.6.2",
@@ -14740,7 +14804,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -15261,7 +15326,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -15445,7 +15511,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -15545,7 +15612,8 @@
     "psl": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
-      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
+      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -15583,7 +15651,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -15594,7 +15663,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -15661,6 +15731,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.3.tgz",
       "integrity": "sha512-piLMOB5Q6LJSVx2XzmdpHktYVb8TmVTy8coXJBFtdkcMC96DknZOuzpAYqCWx2ERZX7xEW+mMi8/wDuMJS/95w==",
+      "dev": true,
       "requires": {
         "node-forge": "^0.8.1",
         "semver": "^5.6.0"
@@ -15706,6 +15777,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.3.5.tgz",
       "integrity": "sha512-bfBvjCCZkitMLd/c66EvZgCI3wUJCEAnwhoFdSWdX4ZvrOCLfFtxyqEDzocqXrDVNgM6qlcKcbQK3Q2iJ0mZuw==",
+      "dev": true,
       "requires": {
         "@rdfjs/data-model": "^1.1.2",
         "relative-to-absolute-iri": "^1.0.0",
@@ -15811,6 +15883,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
       "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
+      "dev": true,
       "requires": {
         "readable-stream": "^3.6.0"
       }
@@ -15969,7 +16042,8 @@
     "relative-to-absolute-iri": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.5.tgz",
-      "integrity": "sha512-sHpUlpF3fRWtTcBa8uBIwQ+Z/YnjDjerocV3q0FrP8T9oZ3z6d61I12ZcGlGr9jW2cQbcCkErCT9XLcN18ZLaQ=="
+      "integrity": "sha512-sHpUlpF3fRWtTcBa8uBIwQ+Z/YnjDjerocV3q0FrP8T9oZ3z6d61I12ZcGlGr9jW2cQbcCkErCT9XLcN18ZLaQ==",
+      "dev": true
     },
     "remarkable": {
       "version": "1.7.4",
@@ -16012,6 +16086,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -16246,7 +16321,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -16268,7 +16344,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "schema-utils": {
       "version": "0.3.0",
@@ -16308,7 +16385,8 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -16833,6 +16911,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -18075,6 +18154,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -18083,7 +18163,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -18154,6 +18235,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -18161,7 +18243,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -18191,7 +18274,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "3.8.3",
@@ -18408,6 +18492,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -18472,7 +18557,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -18503,6 +18589,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -18726,7 +18813,8 @@
     "xmldom": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
   },
   "homepage": "https://alcaeus.hydra.how",
   "dependencies": {
-    "@rdf-esm/data-model": "^0.5.0",
-    "@rdf-esm/formats-common": "^0.5.0",
-    "@rdf-esm/sink-map": "^0.5.0",
+    "@rdfjs/data-model": "^1.1.2",
     "@rdfjs/term-set": "^1.0.1",
-    "@tpluscode/rdf-ns-builders": "^0.1",
+    "@tpluscode/rdf-ns-builders": "^0.2.2",
     "@tpluscode/rdfine": "^0.4.9",
     "clownface": "^0.12.3",
     "es6-url-template": "^1.0.3",
@@ -51,6 +49,10 @@
     "rdf-transform-triple-to-quad": "^1.0.2",
     "readable-stream": "^3.6.0"
   },
+  "peerDependencies": {
+    "@rdf-esm/sink-map": "^0.5.0",
+    "@rdfjs/sink-map": "^1.0.1"
+  },
   "devDependencies": {
     "@babel/helper-create-class-features-plugin": "^7.9.5",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -60,6 +62,8 @@
     "@babel/preset-typescript": "^7.9.0",
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.0",
+    "@rdf-esm/sink-map": "^0.5.0",
+    "@rdfjs/formats-common": "^2.1.0",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/parser-jsonld": "^1.2.0",
     "@rdfjs/parser-n3": "^1.1.3",
@@ -71,6 +75,7 @@
     "@types/rdf-dataset-indexed": "^0.4.4",
     "@types/rdf-ext": "^1.3.7",
     "@types/rdf-js": "^2.0.12",
+    "@types/rdfjs__formats-common": "^2.0.0",
     "@types/rdfjs__namespace": "^1.1.1",
     "@types/rdfjs__parser-jsonld": "^1.2.2",
     "@types/rdfjs__parser-n3": "^1.1.2",

--- a/src/ResourceRepresentation.ts
+++ b/src/ResourceRepresentation.ts
@@ -1,4 +1,4 @@
-import * as $rdf from '@rdf-esm/data-model'
+import * as $rdf from '@rdfjs/data-model'
 import { rdf, hydra } from '@tpluscode/rdf-ns-builders'
 import { RdfResource, ResourceFactory, ResourceIdentifier } from '@tpluscode/rdfine'
 import { Clownface, SingleContextClownface } from 'clownface'

--- a/src/ResourceStore.ts
+++ b/src/ResourceStore.ts
@@ -3,7 +3,7 @@ import cf from 'clownface'
 import TripleToQuadTransform from 'rdf-transform-triple-to-quad'
 import { DatasetIndexed } from 'rdf-dataset-indexed/dataset'
 import { DatasetCore, NamedNode, BaseQuad } from 'rdf-js'
-import * as $rdf from '@rdf-esm/data-model'
+import * as $rdf from '@rdfjs/data-model'
 import ResourceRepresentationImpl, { ResourceRepresentation } from './ResourceRepresentation'
 import { HydraResource } from './Resources'
 

--- a/src/RootSelectors/exactId.ts
+++ b/src/RootSelectors/exactId.ts
@@ -1,4 +1,4 @@
-import * as $rdf from '@rdf-esm/data-model'
+import * as $rdf from '@rdfjs/data-model'
 import { NamedNode } from 'rdf-js'
 import { ResponseWrapper } from '../ResponseWrapper'
 

--- a/src/RootSelectors/redirectTarget.ts
+++ b/src/RootSelectors/redirectTarget.ts
@@ -1,5 +1,5 @@
 import { NamedNode } from 'rdf-js'
-import * as $rdf from '@rdf-esm/data-model'
+import * as $rdf from '@rdfjs/data-model'
 import { ResponseWrapper } from '../ResponseWrapper'
 
 export function redirectTarget(response: ResponseWrapper): NamedNode | undefined {

--- a/src/RootSelectors/trailingSlash.ts
+++ b/src/RootSelectors/trailingSlash.ts
@@ -1,4 +1,4 @@
-import * as $rdf from '@rdf-esm/data-model'
+import * as $rdf from '@rdfjs/data-model'
 import { NamedNode } from 'rdf-js'
 import { ResponseWrapper } from '../ResponseWrapper'
 

--- a/src/alcaeus.ts
+++ b/src/alcaeus.ts
@@ -45,7 +45,7 @@ interface AlcaeusInit<R extends HydraResource = never, D extends DatasetIndexed 
     rootSelectors: [string, RootNodeCandidate][]
     resources: ResourceStore<D>
     datasetFactory: () => D
-    parsers: SinkMap<EventEmitter, Stream>
+    parsers?: SinkMap<EventEmitter, Stream>
 }
 
 export class Alcaeus<R extends HydraResource = never, D extends DatasetIndexed = DatasetIndexed> implements HydraClient<D> {
@@ -66,6 +66,8 @@ export class Alcaeus<R extends HydraResource = never, D extends DatasetIndexed =
     private readonly datasetFactory: () => D;
 
     public constructor({ resources, datasetFactory, rootSelectors, parsers }: AlcaeusInit<R, D>) {
+        if (!parsers) throw new Error('No parsers provided. Consider @rdfjs/formats-common or @rdf-esm/formats-common packages')
+
         this.rootSelectors = rootSelectors
         this.resources = resources
         this.datasetFactory = datasetFactory

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { parsers } from '@rdf-esm/formats-common'
 import { SinkMap } from '@rdf-esm/sink-map'
 import { EventEmitter } from 'events'
 import RdfResource from '@tpluscode/rdfine'
@@ -40,7 +39,7 @@ export function create <D extends DatasetIndexed = DatasetIndexed>(init: Alcaeus
     const alcaeus = new Alcaeus({
         datasetFactory,
         rootSelectors: Object.entries(init.rootSelectors || defaultSelectors),
-        parsers: init.parsers || parsers,
+        parsers: init.parsers,
         resources: new ResourceStoreImpl({
             dataset: init.dataset || datasetFactory(),
             inferences: Object.values(inferences),
@@ -56,5 +55,3 @@ export function create <D extends DatasetIndexed = DatasetIndexed>(init: Alcaeus
 
     return alcaeus
 }
-
-export default create()

--- a/src/inferences/managesBlock.ts
+++ b/src/inferences/managesBlock.ts
@@ -1,5 +1,5 @@
 import cf from 'clownface'
-import * as RDF from '@rdf-esm/data-model'
+import * as RDF from '@rdfjs/data-model'
 import { BaseQuad, DatasetCore } from 'rdf-js'
 import { hydra } from '@tpluscode/rdf-ns-builders'
 

--- a/src/inferences/propertyTypes.ts
+++ b/src/inferences/propertyTypes.ts
@@ -1,5 +1,5 @@
 import cf from 'clownface'
-import * as RDF from '@rdf-esm/data-model'
+import * as RDF from '@rdfjs/data-model'
 import { BaseQuad, DatasetCore } from 'rdf-js'
 import { hydra, rdf } from '@tpluscode/rdf-ns-builders'
 

--- a/tests/FetchUtil-spec.ts
+++ b/tests/FetchUtil-spec.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events'
-import { SinkMap } from '@rdf-esm/sink-map'
+import SinkMap from '@rdfjs/sink-map'
 import { Sink, Stream } from 'rdf-js'
 import fetchPony from 'fetch-ponyfill'
 import * as fetchUtil from '../src/FetchUtil'

--- a/tests/Heracles-spec.ts
+++ b/tests/Heracles-spec.ts
@@ -2,7 +2,7 @@ import 'core-js/es6/array'
 import 'core-js/es6/object'
 import namespace from '@rdfjs/namespace'
 import JsonLdParser from '@rdfjs/parser-jsonld'
-import { SinkMap } from '@rdf-esm/sink-map'
+import SinkMap from '@rdfjs/sink-map'
 import fetchPony from 'fetch-ponyfill'
 import DatasetExt from 'rdf-ext/lib/Dataset'
 import $rdf from 'rdf-ext'
@@ -333,7 +333,7 @@ describe('Hydra', () => {
         let client: HydraClient
 
         beforeEach(() => {
-            client = create()
+            client = create({ parsers })
             fetchResource.mockImplementation(mockedResponse({
                 xhrBuilder: responseBuilder().body(''),
             }))

--- a/tests/ResourceStore-spec.ts
+++ b/tests/ResourceStore-spec.ts
@@ -2,7 +2,7 @@ import { rdf } from '@tpluscode/rdf-ns-builders'
 import RdfResource from '@tpluscode/rdfine'
 import DatasetExt from 'rdf-ext/lib/Dataset'
 import $rdf from 'rdf-ext'
-import * as RDF from '@rdf-esm/data-model'
+import RDF from '@rdfjs/data-model'
 import namespace from '@rdfjs/namespace'
 import ResourceStore, { RepresentationInference } from '../src/ResourceStore'
 

--- a/tests/Resources/HydraResource-spec.ts
+++ b/tests/Resources/HydraResource-spec.ts
@@ -1,4 +1,4 @@
-import { namedNode } from '@rdf-esm/data-model'
+import { namedNode } from '@rdfjs/data-model'
 import namespace from '@rdfjs/namespace'
 import Parser from '@rdfjs/parser-n3'
 import { turtle, TurtleTemplateResult } from '@tpluscode/rdf-string'

--- a/tests/ResponseWrapper-spec.ts
+++ b/tests/ResponseWrapper-spec.ts
@@ -1,7 +1,7 @@
 import fetchPony from 'fetch-ponyfill'
 import * as sinon from 'sinon'
 import { EventEmitter } from 'events'
-import { SinkMap } from '@rdf-esm/sink-map'
+import SinkMap from '@rdfjs/sink-map'
 import { Stream } from 'rdf-js'
 import ResponseWrapper from '../src/ResponseWrapper'
 import { Bodies } from './test-objects'

--- a/tests/index-spec.ts
+++ b/tests/index-spec.ts
@@ -1,4 +1,4 @@
-import { SinkMap } from '@rdf-esm/sink-map'
+import SinkMap from '@rdfjs/sink-map'
 import { Stream } from 'rdf-js'
 import { EventEmitter } from 'events'
 import { create } from '../src'

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -5,7 +5,7 @@ import stringToStream from 'string-to-stream'
 import rdf from 'rdf-ext'
 import Parser from '@rdfjs/parser-n3'
 import { prefixes } from '@zazuko/rdf-vocabularies'
-import { parsers } from '@rdf-esm/formats-common'
+import { parsers } from '@rdfjs/formats-common'
 
 const parser = new Parser()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "CommonJS",
+    "module": "ESNext",
     "outDir": ".",
     "moduleResolution": "node",
     "sourceMap": false,


### PR DESCRIPTION
Turns out that seamless support for `type: module` packages is still a long way ahead

This PR removes direct dependencies which are modules-only. 

- `@rdfjs/data-model` is back 😞 
- parsers become a required parameter to create the client. can be either `@rdfjs/formats-common` or `@rdf-esm/formats-common`

default export got removed from the main module